### PR TITLE
Fix dtype mismatch for non-bfloat16 parameter

### DIFF
--- a/normuon.py
+++ b/normuon.py
@@ -40,6 +40,8 @@ def normuon_update(grad, momentum, second_momentum, beta=0.95, beta2=0.95, ns_st
         original_shape = update.shape
         update = update.reshape(update.size(0), -1)
     update = zeropower_via_newtonschulz5(update, steps=ns_steps)
+    update = update.to(grad.dtype)
+
     if original_shape is not None:
         update = update.reshape(original_shape)
     ################ NorMuon added ###################


### PR DESCRIPTION
This cast should prevent lerp_ and mul_ operations from crashing when the optimizer encounters fp32, fp16, or AMP setups, ensuring the output of the bfloat16 Newton-Schulz iteration matches the original parameter dtype. Without this, the optimizer won't work with non-bfloat16 parameters.

There should not be any significant performance degradation.